### PR TITLE
Provide feedback

### DIFF
--- a/class-inject/src/main/java/datadog/instrument/classinject/ClassInjector.java
+++ b/class-inject/src/main/java/datadog/instrument/classinject/ClassInjector.java
@@ -43,6 +43,7 @@ public final class ClassInjector {
    *
    * @param bytecode the named bytecode to inject
    * @return list of injected classes
+   * @throws IllegalStateException if class injection is not enabled
    */
   public static List<Class<?>> injectBootClasses(Map<String, byte[]> bytecode) {
     return (List<Class<?>>) classDefiner().apply(bytecode, null);
@@ -54,6 +55,7 @@ public final class ClassInjector {
    * @param bytecode the named bytecode to inject
    * @param cl the class-loader to use
    * @return list of injected classes
+   * @throws IllegalStateException if class injection is not enabled
    */
   public static List<Class<?>> injectClasses(Map<String, byte[]> bytecode, ClassLoader cl) {
     return (List<Class<?>>) classDefiner().apply(bytecode, cl);
@@ -65,6 +67,7 @@ public final class ClassInjector {
    * @param bytecode the named bytecode to inject
    * @param pd the protection domain to use
    * @return list of injected classes
+   * @throws IllegalStateException if class injection is not enabled
    */
   public static List<Class<?>> injectClasses(Map<String, byte[]> bytecode, ProtectionDomain pd) {
     return (List<Class<?>>) classDefiner().apply(bytecode, pd);
@@ -74,7 +77,7 @@ public final class ClassInjector {
 
   private static BiFunction classDefiner() {
     if (classDefiner == null) {
-      throw new UnsupportedOperationException("Class injection not enabled");
+      throw new IllegalStateException("Class injection not enabled");
     }
     return classDefiner;
   }
@@ -85,6 +88,7 @@ public final class ClassInjector {
    * Enables class injection via {@link Instrumentation}.
    *
    * @param inst the instrumentation instance
+   * @throws UnsupportedOperationException if class injection is not available
    */
   public static void enableClassInjection(Instrumentation inst) {
     if (classDefiner != null) {


### PR DESCRIPTION
# What Does This Do

This PR  provides small feedback about the newly created project.
The commits are suggestions only, feel free to cherry-pick them or not.
They should not be considered as change request, only change examples.

### Questions

* `datadog.instrument.classmatch.ClassHeader#interfaces()`
Is it okay to allocate an `ArrayList` every time the interfaces are accessed?
Would accessing the array be good enough? (or is it about defensive copy?)
Same applies for `fields`, `methods`, and `annotations` from `datadog.instrument.classmatch.ClassOutline`.

* `datadog.instrument.classmatch.ClassHeader#access`
What about documenting how to test the value? It can be referring to the JVMLS or referring to `java.lang.reflect.Modifier` for example.
It would make it easier for the API consumer to test flags presence with existing constants.
Same applies for `datadog.instrument.classmatch.FieldOutline#access`.

* `datadog.instrument.classmatch.TypeMatcher`
Could `is(String)` be useful?

* I could not find usage / documentation about  `ClassInfoCache`, `ClassNameFilter`, `ClassNameTrie`
It could be useful to explicit the feature in the README too for discoverability, or to move them to utils if they are internal optimization only.

### Suggestion

* `class-match` module source structure
I would introduce package to help with discoverability:
  * parser (parse, outline, hearder)
  * matcher (all matcher interfaces and internal implementation)
  * data structure (cache, filter, trie)

* `datadog.instrument.classmatch.ClassFile`
What about moving the parsing of fields and methods to their related classes?
This would reduce the `ClassFile` complexity to avoid trying to parse everything in one place.

### Nitpick

* `datadog.instrument.classmatch.ClassFile` is more about parser / reader than file / file system.

* `datadog.instrument.classmatch.ClassMatcher#declares(java.util.function.IntPredicate, datadog.instrument.classmatch.FieldMatcher)`
This kind of method - using two predicates / filters on the same type feels weird when using the fluent approach.
I would have expected to use `declares(field("fieldname").access(Modifier::isPublic))` rather than `declares(Modifier::isPublic, field("fieldname"))` because the "fluent" API allow me to build / specify the filter on the fly directly on the type I’m filtering -- the feeling is a bit hard to express, sorry.
To illustrate what happened to me, I had to look at the implementation to check if you were doing some specific optimization as the fluent way seem more natural, and I could not find a reason to have the overloaded method.

<!-- A brief description of the change being made with this pull request. -->

# Motivation

Provide preliminary feedback before wider adoption.

<!-- What inspired you to submit this pull request? -->

# Additional Notes


# Contributor Checklist

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
