### PR TITLE
Fix VerifyError when using class-inject with `-Xverify:all`

### DIFF
--- a/class-inject/build.gradle.kts
+++ b/class-inject/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 dependencies {
   implementation(libs.asm)
   implementation(project(":utils"))
+
+  testImplementation(sourceSets["glue"].output)
+  testImplementation(libs.asm.util)
 }
 
 // class-inject generates glue bytecode at build-time to provide access to Unsafe.defineClass

--- a/class-inject/src/glue/java/datadog/instrument/glue/DefineClassGlueGenerator.java
+++ b/class-inject/src/glue/java/datadog/instrument/glue/DefineClassGlueGenerator.java
@@ -116,7 +116,7 @@ final class DefineClassGlueGenerator {
    * @param unsafeNamespace which Unsafe to use for boot injection
    * @return glue to access {@code ClassLoader.defineClass}
    */
-  private static byte[] generateBytecode(String unsafeNamespace) {
+  static byte[] generateBytecode(String unsafeNamespace) {
 
     // use Unsafe to define boot classes that have no class-loader
     final String unsafeClass = unsafeNamespace + "/Unsafe";
@@ -172,6 +172,7 @@ final class DefineClassGlueGenerator {
     final Label defineBootClass = new Label();
     final Label storeBootClass = new Label();
     final Label loadBootClass = new Label();
+    final Label lookupBootClass = new Label();
     final Label rethrowOriginal = new Label();
     final Label returnDefinedClasses = new Label();
 
@@ -199,7 +200,7 @@ final class DefineClassGlueGenerator {
 
     // fall back and see if the boot class is already loaded if defining it fails
     mv.visitTryCatchBlock(defineBootClass, storeBootClass, loadBootClass, null);
-    mv.visitTryCatchBlock(loadBootClass, rethrowOriginal, rethrowOriginal, null);
+    mv.visitTryCatchBlock(lookupBootClass, rethrowOriginal, rethrowOriginal, null);
 
     // -------- SHARED SETUP CODE  --------
 
@@ -389,6 +390,8 @@ final class DefineClassGlueGenerator {
     // see if the boot class has already been defined
     mv.visitLabel(loadBootClass);
     mv.visitVarInsn(ASTORE, originalError);
+    // must be after originalError is stored, or the handler can't rely on it being set
+    mv.visitLabel(lookupBootClass);
     mv.visitVarInsn(ALOAD, className);
     mv.visitInsn(ICONST_0); // initialize=false
     mv.visitInsn(ACONST_NULL);

--- a/class-inject/src/test/java/datadog/instrument/glue/DefineClassGlueGeneratorTest.java
+++ b/class-inject/src/test/java/datadog/instrument/glue/DefineClassGlueGeneratorTest.java
@@ -1,0 +1,25 @@
+package datadog.instrument.glue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.CheckClassAdapter;
+
+class DefineClassGlueGeneratorTest {
+
+  @ParameterizedTest
+  @ValueSource(strings = {"sun/misc", "jdk/internal/misc"})
+  void generatedBytecodePassesVerification(String unsafeNamespace) {
+    byte[] bytecode = DefineClassGlueGenerator.generateBytecode(unsafeNamespace);
+    StringWriter errors = new StringWriter();
+
+    // perform strict class verification, like -Xverify:all
+    CheckClassAdapter.verify(new ClassReader(bytecode), false, new PrintWriter(errors));
+
+    assertThat(errors.toString()).isEmpty();
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ jmh-plugin = "0.7.3"
 [libraries]
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
+asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }


### PR DESCRIPTION
# What Does This Do

The originalError local was stored as the first instruction inside the try range that protects it, so the verifier's async-exception frame at the handler couldn't assume it was initialized, causing a VerifyError on JVMs that verify bootstrap-loader-defined classes (e.g. `-Xverify:all`). Move the try range to start after the store instead.

# Motivation

Fixes:

```
java.lang.UnsupportedOperationException
  at datadog.instrument.classinject.ClassInjector.enableClassInjection(ClassInjector.java:141)
  at datadog.trace.bootstrap.Agent.start(Agent.java:226)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  at datadog.trace.bootstrap.AgentBootstrap.agentmainImpl(AgentBootstrap.java:166)
  at datadog.trace.bootstrap.AgentBootstrap.agentmain(AgentBootstrap.java:73)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  at datadog.trace.bootstrap.AgentPreCheck.continueBootstrap(AgentPreCheck.java:172)
  at datadog.trace.bootstrap.AgentPreCheck.agentmain(AgentPreCheck.java:27)
  at datadog.trace.bootstrap.AgentPreCheck.premain(AgentPreCheck.java:20)
  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:560)
  at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:572)
Caused by: java.lang.VerifyError
  at java.base/java.lang.ClassLoader.defineClass0(Native Method)
  at java.base/java.lang.System$2.defineClass(System.java:2395)
  at java.base/java.lang.invoke.MethodHandles$Lookup$ClassDefiner.defineClass(MethodHandles.java:2505)
  at java.base/java.lang.invoke.MethodHandles$Lookup$ClassDefiner.defineClassAsLookup(MethodHandles.java:2484)
  at java.base/java.lang.invoke.MethodHandles$Lookup.defineHiddenClass(MethodHandles.java:2150)
  at java.base/java.lang.Class.forName(Unknown Source)
  at datadog.instrument.classinject.ClassInjector.injectViaForName(ClassInjector.java:179)
  at datadog.instrument.classinject.ClassInjector.enableClassInjection(ClassInjector.java:139)
  ... 14 more
```

On systems with strict class verification turned on for all classes, such as `-Xverify:all`

Note when this fails the downstream agent falls back to a different approach, so there's no actual impact on the application - but this fix will stop it from having to do that fall back on those few deployments with full verification enabled.

# Contributor Checklist

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
